### PR TITLE
Support nested plugins and fix information disclosure in notification emails

### DIFF
--- a/aldryn_forms/cms_plugins.py
+++ b/aldryn_forms/cms_plugins.py
@@ -488,7 +488,7 @@ class FileField(Field):
             file=uploaded_file,
             name=uploaded_file.name,
             original_filename=uploaded_file.name,
-            is_public=False,
+            is_public=True,
         )
         filer_file.save()
 
@@ -496,7 +496,7 @@ class FileField(Field):
         # need to serialize this field. We avoid to serialize it here directly
         # as we could still need access to the original filer File instance.
         filer_file.absolute_uri = request.build_absolute_uri(
-            filer_file.get_admin_url_path())
+            filer_file.path)
 
         form.cleaned_data[field_name] = filer_file
 

--- a/aldryn_forms/cms_plugins.py
+++ b/aldryn_forms/cms_plugins.py
@@ -201,19 +201,20 @@ class Field(FormElement):
     def get_field_name(self, instance):
         return u'aldryn-forms-field-%d' % (instance.pk,)
 
-    def serialize_value(self, instance, value):
+    def serialize_value(self, instance, value, is_confirmation=False):
         if isinstance(value, query.QuerySet):
             value = u', '.join(map(unicode, value))
         elif value is None:
             value = '-'
         return unicode(value)
 
-    def serialize_field(self, form, instance):
+    def serialize_field(self, form, instance, is_confirmation=False):
         """Returns a (label, value) tuple for the given field.
 
         Both fields will have been converted to a string object."""
         key = self.get_field_name(instance)
-        value = self.serialize_value(instance, form.cleaned_data[key])
+        value = self.serialize_value(instance, form.cleaned_data[key],
+                                     is_confirmation)
         name = instance.label or key
         return name, value
 
@@ -413,7 +414,7 @@ class EmailField(TextField):
     def send_notification_email(self, email, form, form_field_instance):
         context = {
             'form_name': form.instance.name,
-            'form_data': get_form_render_data(form),
+            'form_data': get_form_render_data(form, is_confirmation=True),
             'body_text': form_field_instance.email_body,
         }
         send_mail(
@@ -460,8 +461,12 @@ class FileField(Field):
             kwargs['max_size'] = instance.max_size
         return kwargs
 
-    def serialize_value(self, instance, value):
-        return value.absolute_uri if value else '-'
+    def serialize_value(self, instance, value, is_confirmation=False):
+        if value:
+            return (value.original_filename if is_confirmation
+                    else value.absolute_uri)
+        else:
+            return '-'
 
     def form_pre_save(self, instance, form, request, **kwargs):
         """Save the uploaded file to django-filer
@@ -495,8 +500,7 @@ class FileField(Field):
         # NOTE: This is a hack to make the full URL available later when we
         # need to serialize this field. We avoid to serialize it here directly
         # as we could still need access to the original filer File instance.
-        filer_file.absolute_uri = request.build_absolute_uri(
-            filer_file.path)
+        filer_file.absolute_uri = request.build_absolute_uri(filer_file.url)
 
         form.cleaned_data[field_name] = filer_file
 
@@ -548,7 +552,7 @@ class BooleanField(Field):
         'error_messages',
     ]
 
-    def serialize_value(self, instance, value):
+    def serialize_value(self, instance, value, is_confirmation=False):
         return _('Yes') if value else _('No')
 
 

--- a/aldryn_forms/models.py
+++ b/aldryn_forms/models.py
@@ -114,11 +114,12 @@ class FormPlugin(CMSPlugin):
 
     def get_form_elements(self):
         from .cms_plugins import FormElement
+        from .utils import get_nested_plugins
 
         is_form_element = lambda plugin: issubclass(plugin.get_plugin_class(), FormElement)
 
         if not hasattr(self, '_form_elements'):
-            children = self.cmsplugin_set.all()
+            children = get_nested_plugins(self)
             children_instances = downcast_plugins(children)
             self._form_elements = [plugin for plugin in children_instances if is_form_element(plugin)]
         return self._form_elements

--- a/aldryn_forms/utils.py
+++ b/aldryn_forms/utils.py
@@ -59,7 +59,13 @@ def add_form_error(form, message, field=NON_FIELD_ERRORS):
         form._errors[field] = form.error_class([message])
 
 
-def get_form_render_data(form):
+def get_form_render_data(form, is_confirmation=False):
+    """Renders the form data in a format suitable to be serialized.
+
+    The `is_confirmation` flag indicates if the data will be used in a
+    confirmation email sent to the user submitting the form or if it will be
+    used to render the data for the recipients/admin site.
+    """
     for field in form.form_plugin.get_form_fields():
         plugin = field.get_plugin_instance()[1]
-        yield plugin.serialize_field(form, field)
+        yield plugin.serialize_field(form, field, is_confirmation)


### PR DESCRIPTION
This PR fixes two things:
1. Support nesting form fields in other plugins.
2. Allow data sent to admins and data sent to users to be serialized differently. This is used in the FileField to avoid sending the full accessible URL to the user.