### PR TITLE
hide all fields except theme when notification form is created

### DIFF
--- a/aldryn_forms/contrib/email_notifications/cms_plugins.py
+++ b/aldryn_forms/contrib/email_notifications/cms_plugins.py
@@ -16,9 +16,20 @@ from .models import EmailNotification, EmailNotificationFormPlugin
 logger = logging.getLogger(__name__)
 
 
-class EmailNotificationInline(admin.StackedInline):
-    model = EmailNotification
+class NewEmailNotificationInline(admin.StackedInline):
     extra = 1
+    fields = ['theme']
+    model = EmailNotification
+    verbose_name = _('new email notification')
+    verbose_name_plural = _('new email notifications')
+
+    def get_queryset(self, request):
+        queryset = super(NewEmailNotificationInline, self).get_queryset(request)
+        return queryset.none()
+
+
+class ExistingEmailNotificationInline(admin.StackedInline):
+    model = EmailNotification
     fieldsets = [
         (
             None,
@@ -46,6 +57,9 @@ class EmailNotificationInline(admin.StackedInline):
     text_variables_help_text = _('variables can be used with by '
                                  'wrapping with "${variable}" like ${variable}')
 
+    def has_add_permission(self, request):
+        return False
+
     def text_variables(self, obj):
         if obj.pk is None:
             return ''
@@ -63,7 +77,10 @@ class EmailNotificationInline(admin.StackedInline):
 class EmailNotificationForm(FormPlugin):
     name = _('Email Notification Form')
     model = EmailNotificationFormPlugin
-    inlines = [EmailNotificationInline]
+    inlines = [
+        ExistingEmailNotificationInline,
+        NewEmailNotificationInline
+    ]
 
     fieldsets = [
         (
@@ -75,6 +92,15 @@ class EmailNotificationForm(FormPlugin):
             {'fields': ['redirect_type', 'page', 'url']}
         )
     ]
+
+    def get_inline_instances(self, request, obj=None):
+        inlines = super(EmailNotificationForm, self).get_inline_instances(request, obj)
+
+        if obj is None:
+            # remove the first inline which is ExistingEmailNotificationInline
+            # if we're first creating this object.
+            inlines = inlines[1:]
+        return inlines
 
     def send_notifications(self, instance, form):
         try:

--- a/aldryn_forms/contrib/email_notifications/cms_plugins.py
+++ b/aldryn_forms/contrib/email_notifications/cms_plugins.py
@@ -97,9 +97,10 @@ class EmailNotificationForm(FormPlugin):
         inlines = super(EmailNotificationForm, self).get_inline_instances(request, obj)
 
         if obj is None:
-            # remove the first inline which is ExistingEmailNotificationInline
+            # remove ExistingEmailNotificationInline inline instance
             # if we're first creating this object.
-            inlines = inlines[1:]
+            inlines = [inline for inline in inlines
+                       if not isinstance(inline, ExistingEmailNotificationInline)]
         return inlines
 
     def send_notifications(self, instance, form):

--- a/aldryn_forms/contrib/email_notifications/models.py
+++ b/aldryn_forms/contrib/email_notifications/models.py
@@ -97,7 +97,7 @@ class EmailNotification(models.Model):
     def clean(self):
         recipient_email = self.get_recipient_email()
 
-        if not recipient_email:
+        if self.pk and not recipient_email:
             message = ugettext('Please provide a recipient.')
             raise ValidationError(message)
 


### PR DESCRIPTION
The reason for this is, when a user would go to create their email notification a few things would happen:

* no variables show up because the notification has no form tied to it
* ckeditor field would not initialize, I think this is known behavior when the object is not saved yet.

To avoid these issues, I created two inlines, one is for creating the notification and the other for editing, plus I make sure the editing one is not displayed if the parent object in this case the form is not saved.