### PR TITLE
Feature/custom variables

### DIFF
--- a/aldryn_forms/cms_plugins.py
+++ b/aldryn_forms/cms_plugins.py
@@ -590,7 +590,7 @@ class BooleanField(Field):
     ]
 
     def serialize_value(self, instance, value, is_confirmation=False):
-        return _('Yes') if value else _('No')
+        return ugettext('Yes') if value else ugettext('No')
 
 
 class SelectOptionInline(TabularInline):

--- a/aldryn_forms/cms_plugins.py
+++ b/aldryn_forms/cms_plugins.py
@@ -166,7 +166,10 @@ class FormPlugin(FieldContainer):
         return form_fields
 
     def get_form_kwargs(self, instance, request):
-        kwargs = {'form_plugin': instance}
+        kwargs = {
+            'form_plugin': instance,
+            'request': request,
+        }
 
         if request.method in ('POST', 'PUT'):
             kwargs['data'] = request.POST.copy()

--- a/aldryn_forms/contrib/email_notifications/cms_plugins.py
+++ b/aldryn_forms/contrib/email_notifications/cms_plugins.py
@@ -86,9 +86,18 @@ class ExistingEmailNotificationInline(admin.StackedInline):
         if obj.pk is None:
             return ''
 
-        # list of tuples - [('value', 'label')]
-        variable_choices = obj.form.get_notification_text_context_keys_as_choices()
-        li_items = (u'<li>{0} | {1}</li>'.format(*var) for var in variable_choices)
+        # list of tuples - [('category', [('value', 'label')])]
+        choices_by_category = obj.form.get_notification_text_context_keys_as_choices()
+
+        li_items = []
+
+        for category, choices in choices_by_category:
+            # <li>field_1</li><li>field_2</li>
+            fields_li = u''.join((u'<li>{0} | {1}</li>'.format(*var) for var in choices))
+
+            if fields_li:
+                li_item = u'<li>{0}</li><ul>{1}</ul>'.format(category, fields_li)
+                li_items.append(li_item)
         unordered_list = u'<ul>{0}</ul>'.format(u''.join(li_items))
         help_text = u'<p class="help">{0}</p>'.format(self.text_variables_help_text)
         return unordered_list + '\n' + help_text

--- a/aldryn_forms/contrib/email_notifications/cms_plugins.py
+++ b/aldryn_forms/contrib/email_notifications/cms_plugins.py
@@ -10,6 +10,7 @@ from cms.plugin_pool import plugin_pool
 from aldryn_forms.cms_plugins import FormPlugin
 from aldryn_forms.validators import is_valid_recipient
 
+from .notification import DefaultNotificationConf
 from .models import EmailNotification, EmailNotificationFormPlugin
 
 
@@ -81,6 +82,7 @@ class EmailNotificationForm(FormPlugin):
         ExistingEmailNotificationInline,
         NewEmailNotificationInline
     ]
+    notification_conf_class = DefaultNotificationConf
 
     fieldsets = [
         (

--- a/aldryn_forms/contrib/email_notifications/cms_plugins.py
+++ b/aldryn_forms/contrib/email_notifications/cms_plugins.py
@@ -87,7 +87,7 @@ class ExistingEmailNotificationInline(admin.StackedInline):
             return ''
 
         # list of tuples - [('value', 'label')]
-        variable_choices = obj.get_text_variable_choices()
+        variable_choices = obj.form.get_notification_text_context_keys_as_choices()
         li_items = (u'<li>{0} | {1}</li>'.format(*var) for var in variable_choices)
         unordered_list = u'<ul>{0}</ul>'.format(u''.join(li_items))
         help_text = u'<p class="help">{0}</p>'.format(self.text_variables_help_text)

--- a/aldryn_forms/contrib/email_notifications/cms_plugins.py
+++ b/aldryn_forms/contrib/email_notifications/cms_plugins.py
@@ -100,7 +100,7 @@ class ExistingEmailNotificationInline(admin.StackedInline):
                 li_items.append(li_item)
         unordered_list = u'<ul>{0}</ul>'.format(u''.join(li_items))
         help_text = u'<p class="help">{0}</p>'.format(self.text_variables_help_text)
-        return unordered_list + '\n' + help_text
+        return unordered_list + u'\n' + help_text
     text_variables.allow_tags = True
     text_variables.short_description = _('available text variables')
 

--- a/aldryn_forms/contrib/email_notifications/helpers.py
+++ b/aldryn_forms/contrib/email_notifications/helpers.py
@@ -2,8 +2,30 @@
 from string import Template
 
 
-def get_theme_template_name(theme, format='html'):
-    return 'aldryn_forms/email_notifications/emails/themes/{0}.{1}'.format(theme, format)
+def get_template_name(base, name, format='txt'):
+    filename = '{0}.{1}'.format(name, format)
+
+    if not base.endswith('/'):
+        base += '/'
+    return '{0}{1}'.format(base, filename)
+
+
+def get_email_template_name(format='txt'):
+    template_name = get_template_name(
+        base='aldryn_forms/email_notifications/emails/',
+        name='body',
+        format=format,
+    )
+    return template_name
+
+
+def get_theme_template_name(theme, format='txt'):
+    template_name = get_template_name(
+        base='aldryn_forms/email_notifications/emails/themes',
+        name=theme,
+        format=format,
+    )
+    return template_name
 
 
 def render_text(message, context):

--- a/aldryn_forms/contrib/email_notifications/helpers.py
+++ b/aldryn_forms/contrib/email_notifications/helpers.py
@@ -1,30 +1,31 @@
 # -*- coding: utf-8 -*-
+import os
+
 from string import Template
 
-
-def get_template_name(base, name, format='txt'):
-    filename = '{0}.{1}'.format(name, format)
-
-    if not base.endswith('/'):
-        base += '/'
-    return '{0}{1}'.format(base, filename)
+from emailit.utils import get_template_name
 
 
-def get_email_template_name(format='txt'):
+EMAIL_TEMPLATES_BASE = 'aldryn_forms/email_notifications/emails/'
+
+EMAIL_THEMES_PATH = os.path.join(EMAIL_TEMPLATES_BASE, 'themes')
+EMAIL_NOTIFICATIONS_PATH = os.path.join(EMAIL_TEMPLATES_BASE, 'notification')
+
+
+def get_email_template_name(name='body', suffix='txt'):
     template_name = get_template_name(
-        base='aldryn_forms/email_notifications/emails/',
-        name='body',
-        format=format,
+        # we don't care about language specific templates
+        language=None,
+        base=EMAIL_NOTIFICATIONS_PATH,
+        part=name,
+        suffix=suffix,
     )
     return template_name
 
 
-def get_theme_template_name(theme, format='txt'):
-    template_name = get_template_name(
-        base='aldryn_forms/email_notifications/emails/themes',
-        name=theme,
-        format=format,
-    )
+def get_theme_template_name(theme, suffix='txt'):
+    filename = '{0}.{1}'.format(theme, suffix)
+    template_name = os.path.join(EMAIL_THEMES_PATH, filename)
     return template_name
 
 

--- a/aldryn_forms/contrib/email_notifications/models.py
+++ b/aldryn_forms/contrib/email_notifications/models.py
@@ -147,8 +147,8 @@ class EmailNotification(models.Model):
             'form_data': form.get_serialized_field_choices(),
             'form_name': self.form.name,
             'email_notification': self,
-            'email_html_theme': get_template(format='html'),
-            'email_txt_theme': get_template(format='txt'),
+            'email_html_theme': get_template(suffix='html'),
+            'email_txt_theme': get_template(suffix='txt'),
         }
         return context
 
@@ -168,12 +168,13 @@ class EmailNotification(models.Model):
             # needs to be empty string because emailit expects a string
             # it's empty so the template lookup fails.
             'template_base': '',
-            'body_templates': [get_email_template_name('txt')],
+            'body_templates': [get_email_template_name(name='body', suffix='txt')],
+            'subject_templates': [get_email_template_name(name='subject', suffix='txt')],
         }
 
         if notification_conf.html_email_format_enabled:
             # we only want to render html template if html format is enabled.
-            kwargs['html_templates'] = [get_email_template_name('html')]
+            kwargs['html_templates'] = [get_email_template_name(name='body', suffix='html')]
 
         render = partial(render_text, context=text_context)
 

--- a/aldryn_forms/contrib/email_notifications/models.py
+++ b/aldryn_forms/contrib/email_notifications/models.py
@@ -44,7 +44,7 @@ class EmailNotificationFormPlugin(FormPlugin):
 
     def get_notification_text_context(self, form):
         notification_conf = self.get_notification_conf()
-        text_context = notification_conf.get_text_context()
+        text_context = notification_conf.get_context(form)
         return text_context
 
     def get_notification_text_context_keys_as_choices(self):
@@ -155,7 +155,7 @@ class EmailNotification(models.Model):
     def get_email_kwargs(self, form):
         form_plugin = self.form
 
-        text_context = form_plugin.get_text_context(form)
+        text_context = form_plugin.get_notification_text_context(form)
 
         email_context = self.get_email_context(form)
         email_context['text_context'] = text_context

--- a/aldryn_forms/contrib/email_notifications/models.py
+++ b/aldryn_forms/contrib/email_notifications/models.py
@@ -51,7 +51,7 @@ class EmailNotificationFormPlugin(FormPlugin):
 
     def get_notification_text_context_keys_as_choices(self):
         notification_conf = self.get_notification_conf()
-        choices =  notification_conf.get_text_context_keys_as_choices()
+        choices =  notification_conf.get_context_keys_as_choices()
         return choices
 
 

--- a/aldryn_forms/contrib/email_notifications/models.py
+++ b/aldryn_forms/contrib/email_notifications/models.py
@@ -34,6 +34,15 @@ class EmailNotificationFormPlugin(FormPlugin):
             item.form = self
             item.save()
 
+    def get_text_context(self, form):
+        text_context = form.get_cleaned_data()
+        text_context['form_name'] = self.form.name
+        return text_context
+
+    def get_text_variable_choices(self):
+        choices =  ['', list(self.form.get_form_fields_as_choices())]
+        return choices
+
 
 class EmailNotification(models.Model):
     theme = models.CharField(
@@ -138,8 +147,7 @@ class EmailNotification(models.Model):
         return context
 
     def get_email_kwargs(self, form):
-        text_context = form.get_cleaned_data()
-        text_context['form_name'] = self.form.name
+        text_context = self.form.get_text_context(form)
 
         email_context = self.get_email_context(form)
         email_context['text_context'] = text_context

--- a/aldryn_forms/contrib/email_notifications/models.py
+++ b/aldryn_forms/contrib/email_notifications/models.py
@@ -29,8 +29,6 @@ EMAIL_THEMES = getattr(
 
 class EmailNotificationFormPlugin(FormPlugin):
 
-    custom_text_context_keys = None
-
     class Meta:
         proxy = True
 

--- a/aldryn_forms/contrib/email_notifications/notification.py
+++ b/aldryn_forms/contrib/email_notifications/notification.py
@@ -5,7 +5,8 @@ from django.utils.translation import ugettext
 class BaseNotificationConf(object):
     # list of extra context keys available for email content/headers
     # format should be:
-    # [(Title, [field_1, field_2])]
+    # [(Title, [(field_1, field_1_label), (field_2, field_2_label)])]
+    # fields have to be valid python identifiers
     custom_text_context_choices = None
 
     # should we allow the user to configure the email txt format?
@@ -25,7 +26,14 @@ class BaseNotificationConf(object):
     def get_context(self, form):
         text_context = form.get_cleaned_data()
         text_context['form_name'] = self.form_plugin.name
+
+        if self.custom_text_context_choices:
+            custom_context = self.get_custom_text_context(form)
+            text_context.update(custom_context)
         return text_context
+
+    def get_custom_text_context(self, form):
+        return {}
 
     def get_context_keys_as_choices(self):
         choices =  [

--- a/aldryn_forms/contrib/email_notifications/notification.py
+++ b/aldryn_forms/contrib/email_notifications/notification.py
@@ -44,7 +44,7 @@ class BaseNotificationConf(object):
         ]
 
         if self.custom_text_context_choices:
-            choices += self.custom_text_context_choices
+            choices += list(self.custom_text_context_choices)
         return choices
 
 

--- a/aldryn_forms/contrib/email_notifications/notification.py
+++ b/aldryn_forms/contrib/email_notifications/notification.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from django.utils.translation import ugettext
+
+
+class BaseNotificationConf(object):
+    # list of extra context keys available for email content/headers
+    custom_text_context_keys = None
+
+    # should we allow the user to configure the email txt format?
+    # this is not the same as the html option above
+    # we can't disable txt format but we can choose to not display
+    # it on the admin.
+    txt_email_format_configurable = True
+
+    # should we send out an html version of the email?
+    # by design if the html version of email is enabled
+    # then is configurable via the admin.
+    html_email_format_enabled = True
+
+    def __init__(self, form_plugin):
+        self.form_plugin = form_plugin
+
+    def get_context(self, form):
+        text_context = form.get_cleaned_data()
+        text_context['form_name'] = self.form_plugin.name
+        return text_context
+
+    def get_context_keys_as_choices(self):
+        choices =  [
+            (
+                ugettext('Fields'),
+                list(self.form_plugin.get_form_fields_as_choices())
+            ),
+        ]
+
+        if self.custom_text_context_keys:
+            choices += self.custom_text_context_keys
+        return choices
+
+
+class DefaultNotificationConf(BaseNotificationConf):
+    html_email_format_enabled = True
+    txt_email_format_configurable = True

--- a/aldryn_forms/contrib/email_notifications/notification.py
+++ b/aldryn_forms/contrib/email_notifications/notification.py
@@ -4,7 +4,9 @@ from django.utils.translation import ugettext
 
 class BaseNotificationConf(object):
     # list of extra context keys available for email content/headers
-    custom_text_context_keys = None
+    # format should be:
+    # [(Title, [field_1, field_2])]
+    custom_text_context_choices = None
 
     # should we allow the user to configure the email txt format?
     # this is not the same as the html option above
@@ -33,8 +35,8 @@ class BaseNotificationConf(object):
             ),
         ]
 
-        if self.custom_text_context_keys:
-            choices += self.custom_text_context_keys
+        if self.custom_text_context_choices:
+            choices += self.custom_text_context_choices
         return choices
 
 

--- a/aldryn_forms/contrib/email_notifications/notification.py
+++ b/aldryn_forms/contrib/email_notifications/notification.py
@@ -7,7 +7,7 @@ class BaseNotificationConf(object):
     # format should be:
     # [(Title, [(field_1, field_1_label), (field_2, field_2_label)])]
     # fields have to be valid python identifiers
-    custom_text_context_choices = None
+    custom_context_choices = None
 
     # should we allow the user to configure the email txt format?
     # this is not the same as the html option above
@@ -27,12 +27,12 @@ class BaseNotificationConf(object):
         text_context = form.get_cleaned_data()
         text_context['form_name'] = self.form_plugin.name
 
-        if self.custom_text_context_choices:
-            custom_context = self.get_custom_text_context(form)
+        if self.custom_context_choices:
+            custom_context = self.get_custom_context(form)
             text_context.update(custom_context)
         return text_context
 
-    def get_custom_text_context(self, form):
+    def get_custom_context(self, form):
         return {}
 
     def get_context_keys_as_choices(self):
@@ -43,8 +43,8 @@ class BaseNotificationConf(object):
             ),
         ]
 
-        if self.custom_text_context_choices:
-            choices += list(self.custom_text_context_choices)
+        if self.custom_context_choices:
+            choices += list(self.custom_context_choices)
         return choices
 
 

--- a/aldryn_forms/forms.py
+++ b/aldryn_forms/forms.py
@@ -144,6 +144,7 @@ class FormDataBaseForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         self.form_plugin = kwargs.pop('form_plugin')
+        self.request = kwargs.pop('request')
         super(FormDataBaseForm, self).__init__(*args, **kwargs)
         language = self.form_plugin.language
 


### PR DESCRIPTION
With the new notification config class, we now support custom context keys to be used in email message and the other fields.


![aldryn-forms-notification-variables](https://cloud.githubusercontent.com/assets/994951/8581894/953bddb8-2591-11e5-8d3a-7882cb3791f3.png)
As you can see on the screenshot above, users can register custom variables under a category to make it easier to differentiate.
