### PR TITLE
gracefully handle orphan plugins

### DIFF
--- a/aldryn_forms/helpers.py
+++ b/aldryn_forms/helpers.py
@@ -9,4 +9,4 @@ def is_form_element(plugin):
     cms_plugin = plugin.get_plugin_class_instance(None)
     is_orphan_plugin = cms_plugin.model != plugin.__class__
     is_element_subclass = issubclass(plugin.get_plugin_class(), FormElement)
-    return not is_orphan_plugin and is_element_subclass
+    return (not is_orphan_plugin) and is_element_subclass

--- a/aldryn_forms/helpers.py
+++ b/aldryn_forms/helpers.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+
+def is_form_element(plugin):
+    # import here due because of circular imports
+    from .cms_plugins import FormElement
+
+    # cms_plugins.CMSPlugin subclass
+    cms_plugin = plugin.get_plugin_class_instance(None)
+    is_orphan_plugin = cms_plugin.model != plugin.__class__
+    is_element_subclass = issubclass(plugin.get_plugin_class(), FormElement)
+    return not is_orphan_plugin and is_element_subclass

--- a/aldryn_forms/models.py
+++ b/aldryn_forms/models.py
@@ -21,6 +21,8 @@ except ImportError:  # django < 1.5
 else:
     User = get_user_model()
 
+from .helpers import is_form_element
+
 
 FieldData = namedtuple(
     'FieldData',
@@ -167,13 +169,10 @@ class FormPlugin(CMSPlugin):
         return fields_by_name
 
     def get_form_elements(self):
-        from .cms_plugins import FormElement
         from .utils import get_nested_plugins
 
         if self.child_plugin_instances is None:
             self.child_plugin_instances = self.get_descendants().order_by('tree_id', 'level', 'position')
-
-        is_form_element = lambda plugin: issubclass(plugin.get_plugin_class(), FormElement)
 
         if self._form_elements is None:
             children = get_nested_plugins(self)


### PR DESCRIPTION
Orphan plugin : a CMSPlugin record that has no relationship to the actual plugin class
this could happen if adding plugin and then quitting without saving.