### PR TITLE
Fix cms 3.1 comaptibility issue (mptt ordering)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+0.5.1 (2015-29-09)
+------------------
+* cms 3.1 compatibility fix
+
 0.5.0 (2015-19-08)
 ------------------
 * added django 1.7 & 1.8 compatibility

--- a/aldryn_forms/models.py
+++ b/aldryn_forms/models.py
@@ -19,7 +19,7 @@ from sizefield.models import FileSizeField
 from .helpers import is_form_element
 
 
-USES_TREEBEARD = LooseVersion(cms.__version__) >= LooseVersion('3.1')
+USES_TREEBEARD_ORDERING = LooseVersion(cms.__version__) >= LooseVersion('3.1')
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
 FieldData = namedtuple(
@@ -171,13 +171,13 @@ class FormPlugin(CMSPlugin):
 
         if self.child_plugin_instances is None:
             # 3.1 and 3.0 compatibility
-            if USES_TREEBEARD:
+            if USES_TREEBEARD_ORDERING:
                 # default ordering is by path
-                self.child_plugin_instances = self.get_descendants().order_by(
-                    'path', 'position')
+                ordering = ('path', 'position')
             else:
-                self.child_plugin_instances = self.get_descendants().order_by(
-                    'tree_id', 'level', 'position')
+                ordering = ('tree_id', 'level', 'position')
+            self.child_plugin_instances = self.get_descendants().order_by(
+                *ordering)
 
         if self._form_elements is None:
             children = get_nested_plugins(self)

--- a/aldryn_forms/models.py
+++ b/aldryn_forms/models.py
@@ -173,7 +173,8 @@ class FormPlugin(CMSPlugin):
             # 3.1 and 3.0 compatibility
             if USES_TREEBEARD:
                 # default ordering is by path
-                self.child_plugin_instances = self.get_descendants()
+                self.child_plugin_instances = self.get_descendants().order_by(
+                    'path', 'position')
             else:
                 self.child_plugin_instances = self.get_descendants().order_by(
                     'tree_id', 'level', 'position')

--- a/aldryn_forms/models.py
+++ b/aldryn_forms/models.py
@@ -19,7 +19,7 @@ from sizefield.models import FileSizeField
 from .helpers import is_form_element
 
 
-USES_TREEBEARD_ORDERING = LooseVersion(cms.__version__) >= LooseVersion('3.1')
+CMS_31 = LooseVersion(cms.__version__) >= LooseVersion('3.1')
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
 FieldData = namedtuple(
@@ -171,13 +171,12 @@ class FormPlugin(CMSPlugin):
 
         if self.child_plugin_instances is None:
             # 3.1 and 3.0 compatibility
-            if USES_TREEBEARD_ORDERING:
+            if CMS_31:
                 # default ordering is by path
                 ordering = ('path', 'position')
             else:
                 ordering = ('tree_id', 'level', 'position')
-            self.child_plugin_instances = self.get_descendants().order_by(
-                *ordering)
+            self.child_plugin_instances = self.get_descendants().order_by(*ordering)
 
         if self._form_elements is None:
             children = get_nested_plugins(self)

--- a/aldryn_forms/models.py
+++ b/aldryn_forms/models.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 from collections import defaultdict, namedtuple
+from distutils.version import LooseVersion
 
 from django.conf import settings
 from django.db import models
 from django.utils.datastructures import SortedDict
 from django.utils.translation import ugettext_lazy as _
 
+import cms
 from cms.models.fields import PageField
 from cms.models.pluginmodel import CMSPlugin
 from cms.utils.plugins import downcast_plugins
@@ -17,6 +19,7 @@ from sizefield.models import FileSizeField
 from .helpers import is_form_element
 
 
+USES_TREEBEARD = LooseVersion(cms.__version__) >= LooseVersion('3.1')
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
 FieldData = namedtuple(
@@ -167,7 +170,13 @@ class FormPlugin(CMSPlugin):
         from .utils import get_nested_plugins
 
         if self.child_plugin_instances is None:
-            self.child_plugin_instances = self.get_descendants().order_by('tree_id', 'level', 'position')
+            # 3.1 and 3.0 compatibility
+            if USES_TREEBEARD:
+                # default ordering is by path
+                self.child_plugin_instances = self.get_descendants()
+            else:
+                self.child_plugin_instances = self.get_descendants().order_by(
+                    'tree_id', 'level', 'position')
 
         if self._form_elements is None:
             children = get_nested_plugins(self)


### PR DESCRIPTION
Should now work with both 3.0 and 3.1

Default ordering in treebeard is by ``path`` so no additional ordering is needed.
