### PR TITLE
_asdict() returning empty dict with Py3K

### DIFF
--- a/aldryn_forms/models.py
+++ b/aldryn_forms/models.py
@@ -57,6 +57,9 @@ BaseSerializedFormField = namedtuple(
 
 class SerializedFormField(BaseSerializedFormField):
 
+    # For _asdict() with Py3K
+    __slots__ = ()
+
     @property
     def field_id(self):
         field_label = self.label.strip()


### PR DESCRIPTION
need to share parent dictionary

Form submissions were broken with Python 3.4, as submitted fields were serialized to an empty dictionary.

I saw this hint about ``__slots__`` elsewhere and it resolved the issue.  The [Python doc](https://docs.python.org/3/library/collections.html#collections.somenamedtuple._asdict) mentions defining ``__slots__`` like this for a subclass but did not state this clearly as a functional requirement.  The [data model description](https://docs.python.org/3.4/reference/datamodel.html#notes-on-using-slots) doesn't really clarify it for me either, although it seems to make sense.