### PR TITLE
Allow fields with more than 255 chars 

### DIFF
--- a/aldryn_forms/migrations/0008_auto_20170316_0845.py
+++ b/aldryn_forms/migrations/0008_auto_20170316_0845.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('aldryn_forms', '0007_auto_20170315_1421'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='emailfieldplugin',
+            name='max_value',
+            field=models.PositiveIntegerField(null=True, verbose_name='Max value', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='fieldplugin',
+            name='max_value',
+            field=models.PositiveIntegerField(null=True, verbose_name='Max value', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='fileuploadfieldplugin',
+            name='max_value',
+            field=models.PositiveIntegerField(null=True, verbose_name='Max value', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='imageuploadfieldplugin',
+            name='max_value',
+            field=models.PositiveIntegerField(null=True, verbose_name='Max value', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='textareafieldplugin',
+            name='max_value',
+            field=models.PositiveIntegerField(null=True, verbose_name='Max value', blank=True),
+        ),
+    ]

--- a/aldryn_forms/models.py
+++ b/aldryn_forms/models.py
@@ -4,7 +4,6 @@ import json
 from collections import defaultdict, namedtuple
 
 from django.conf import settings
-from django.core.validators import MaxValueValidator
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.six import text_type
@@ -337,7 +336,6 @@ class FieldPluginBase(CMSPlugin):
         _('Max value'),
         blank=True,
         null=True,
-        validators=[MaxValueValidator(255)]
     )
 
     custom_classes = models.CharField(


### PR DESCRIPTION
The max_value on each form field type is used for max length on all text
types and for max amount of selections on multi choice fields. It was 
limited to 255 due to the previous way how submitted form data was
saved. But that limit does not make sense for a TextArea, which should
not have a limit and the limit size.