### PR TITLE
advanced form plugin: add missing permissions

### DIFF
--- a/aldryn_forms/contrib/email_notifications/migrations/0002_form_plugin_add_missing_permission.py
+++ b/aldryn_forms/contrib/email_notifications/migrations/0002_form_plugin_add_missing_permission.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.auth.models import Permission
+
+
+APP_LABEL = 'email_notifications'
+MODEL_NAME = 'emailnotificationformplugin'
+VERBOSE_MODEL_NAME = 'form (advanced)'
+ACTIONS = ('add', 'change', 'delete')
+
+
+def get_content_type():
+    try:
+        return ContentType.objects.get(app_label=APP_LABEL, model=MODEL_NAME)
+    except ContentType.objects.DoesNotExist:
+        return None
+
+
+def forwards(apps, schema_editor):
+    content_type = get_content_type()
+    if content_type:
+        for action in ACTIONS:
+            Permission.objects.get_or_create(
+                codename='{}_{}'.format(action, MODEL_NAME),
+                content_type=content_type,
+                defaults={
+                    'name': 'Can {} {}'.format(action, VERBOSE_MODEL_NAME)
+                }
+            )
+
+
+def backwards(apps, schema_editor):
+    content_type = get_content_type()
+    if content_type:
+        codenames = [
+            '{}_{}'.format(action, MODEL_NAME)
+            for action in ACTIONS
+        ]
+
+        Permission.objects.filter(
+            codename__in=codenames,
+            content_type=content_type,
+        ).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('email_notifications', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            forwards,
+            reverse_code=backwards,
+        )
+    ]


### PR DESCRIPTION
because this being a proxy model django does not create the correct permission objects. adding them manually with this