### PR TITLE
Fix email notifications migration

### DIFF
--- a/aldryn_forms/contrib/email_notifications/migrations/0002_form_plugin_add_missing_permission.py
+++ b/aldryn_forms/contrib/email_notifications/migrations/0002_form_plugin_add_missing_permission.py
@@ -15,7 +15,7 @@ ACTIONS = ('add', 'change', 'delete')
 def get_content_type():
     try:
         return ContentType.objects.get(app_label=APP_LABEL, model=MODEL_NAME)
-    except ContentType.objects.DoesNotExist:
+    except ContentType.DoesNotExist:
         return None
 
 


### PR DESCRIPTION
Remove 'objects' from the DoesNotExist exception which caused the migrations to fail.