### PR TITLE
add missing translation in email field

### DIFF
--- a/aldryn_forms/models.py
+++ b/aldryn_forms/models.py
@@ -384,7 +384,7 @@ class TextAreaFieldPlugin(FieldPluginBase):
 
 class EmailFieldPlugin(FieldPluginBase):
     email_send_notification = models.BooleanField(
-        verbose_name=('send notification when form is submitted'),
+        verbose_name=_('send notification when form is submitted'),
         default=False,
         help_text=_('When checked, the value of this field will be used to '
                     'send an email notification.')


### PR DESCRIPTION
I found out the `email_send_notification` field was not completely translated to german, so I searched in the source and saw that the verbose name of the field was not translatable. (Missing the `_`)