### PR TITLE
add missing translation in the form & advanced form

### DIFF
--- a/aldryn_forms/cms_plugins.py
+++ b/aldryn_forms/cms_plugins.py
@@ -71,7 +71,7 @@ class FormPlugin(FieldContainer):
                 'url',
             )
         }),
-        ('Advanced Settings', {
+        (_('Advanced Settings'), {
             'classes': ('collapse',),
             'fields': (
                 'form_template',
@@ -239,7 +239,7 @@ class Fieldset(FieldContainer):
                 'legend',
             )
         }),
-        ('Advanced Settings', {
+        (_('Advanced Settings'), {
             'classes': ('collapse',),
             'fields': (
                 'custom_classes',

--- a/aldryn_forms/contrib/email_notifications/cms_plugins.py
+++ b/aldryn_forms/contrib/email_notifications/cms_plugins.py
@@ -48,7 +48,7 @@ class ExistingEmailNotificationInline(admin.StackedInline):
                 'theme',
             )
         }),
-        ('Recipients', {
+        (_('Recipients'), {
             'classes': ('collapse',),
             'fields': (
                 'text_variables',
@@ -89,7 +89,7 @@ class ExistingEmailNotificationInline(admin.StackedInline):
             # add the body_html field only if email is allowed
             # to be sent in html version.
             fields.append('body_html')
-        return [('Email', {
+        return [(_('Email'), {
             'classes': ('collapse',),
             'fields': fields
         })]
@@ -134,7 +134,7 @@ class EmailNotificationForm(FormPlugin):
                 ('page', 'url'),
             )
         }),
-        ('Advanced Settings', {
+        (_('Advanced Settings'), {
             'classes': ('collapse',),
             'fields': (
                 'form_template',


### PR DESCRIPTION
I search explicitly for untranslated string and found some more.
I fixed all but one. (Couldn't find the place where the string comes from. I'll open a Issue for that one)