### PR TITLE
Remove type attribute from textarea

### DIFF
--- a/aldryn_forms/cms_plugins.py
+++ b/aldryn_forms/cms_plugins.py
@@ -505,6 +505,8 @@ class TextAreaField(BaseTextField):
 
     def get_form_field_widget_attrs(self, instance):
         attrs = super(TextAreaField, self).get_form_field_widget_attrs(instance)
+        
+        del attrs['type']
 
         if instance.text_area_columns:
             attrs['cols'] = instance.text_area_columns


### PR DESCRIPTION
Remove unnecessary type attribute from TextAreaField, following the [specification](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea).