### PR TITLE
don't render meta information for hidden fields

### DIFF
--- a/aldryn_forms/templates/aldryn_forms/fields/hiddenfield.html
+++ b/aldryn_forms/templates/aldryn_forms/fields/hiddenfield.html
@@ -1,1 +1,3 @@
-{% extends "aldryn_forms/field.html" %}
+{% load aldryn_forms_tags %}
+
+{% render_form_widget field class=instance.custom_classes %}


### PR DESCRIPTION
A hidden field renders via **{% extends "aldryn_forms/field.html" %}** so label, errors and "Required field" will be added to the page ;)