### PR TITLE
Migration dependency is missing

### DIFF
--- a/aldryn_forms/migrations/0010_auto_20171220_1733.py
+++ b/aldryn_forms/migrations/0010_auto_20171220_1733.py
@@ -28,6 +28,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('aldryn_forms', '0009_auto_20171218_1049'),
+        ('cms', '0006_auto_20160821_1039.py'),
     ]
 
     operations = [

--- a/aldryn_forms/migrations/0010_auto_20171220_1733.py
+++ b/aldryn_forms/migrations/0010_auto_20171220_1733.py
@@ -28,7 +28,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('aldryn_forms', '0009_auto_20171218_1049'),
-        ('cms', '0006_auto_20160821_1039.py'),
+        ('cms', '0006_auto_20160821_1039'),
     ]
 
     operations = [


### PR DESCRIPTION
When I tried to upgrade from 2.2.1 to 3.0.1 I got some errors related to DB fields missing.

Found out that in migration [0010_auto_20171220_1733](https://github.com/aldryn/aldryn-forms/blob/master/aldryn_forms/migrations/0010_auto_20171220_1733.py#L14), the `FieldPlugin._meta.fields` contains fields that were removed from django-cms in [0006_auto_20140924_1110](https://github.com/divio/django-cms/blob/release/3.2.x/cms/migrations/0006_auto_20140924_1110.py) migration.

I don't know exactly how migrations builds models when calling `apps.get_model()`  but it seems that it doesn't include migrations that haven't been marked as required.

How to reproduce:

- Compile those requirements and create a new project with that:
```
dj-database-url==0.4.2
Django==1.9.12
mysqlclient==1.3.10

django-cms==3.4.2
djangocms-text-ckeditor==3.4.0
djangocms-link==2.1.1
django-filer==1.2.7

cmsplugin-filer==1.1.3
django-reversion==1.10.2
djangocms-cascade==0.11.3
djangocms-column==1.7.0
djangocms-file==2.0.2
djangocms-flash==0.3.0
djangocms-googlemap==1.0.2
djangocms-inherit==0.2.2
djangocms-picture==2.0.4
djangocms-style==2.0.1
djangocms-teaser==0.2.0
djangocms-video==2.0.3
django-colorfield==0.1.12
aldryn-forms==2.2.1
```
- Create a form with a field
- Submit data through that form
- Upgrade aldryn-forms to 3.0.1
=> Fails when applying `0010_auto_20171220_1733`